### PR TITLE
EFS volumes variable requires Terraform 1.4 or greater.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">=0.12.3"
+  required_version = ">=1.3.0"
 }


### PR DESCRIPTION
Ran into this error in Concourse
<img width="592" alt="image" src="https://github.com/7Factor/terraform-aws-ecs-http-task/assets/669280/36647261-f6f9-4ab5-a3f4-9a391fecac0a">

It seems that Terraform 1.4 is required for this to be a standard feature.